### PR TITLE
Fixed getting resource and trigger by both warn and fail

### DIFF
--- a/autoremediate/aws/lambda/AWS_EC2_default_vpc_remediate.py
+++ b/autoremediate/aws/lambda/AWS_EC2_default_vpc_remediate.py
@@ -51,7 +51,7 @@ def lambda_handler(event, context):
 
     # If the signature didn't report a failure, exit..
     #
-    if status != 'fail':
+    if (status != 'fail' and status != 'warn'):
         print('=> Nothing to do.')
         exit()
 
@@ -69,7 +69,7 @@ def lambda_handler(event, context):
     region = re.sub('_','-',regions['attributes']['code'])
 
     try:
-        vpc_id = metadata['attributes']['data']['resource_id']
+        vpc_id = alert['data']['attributes']['resource']
     except:
         print('=> No VPC to evaluate.')
     else:

--- a/autoremediate/aws/lambda/AWS_EC2_ebs_recent_snapshot_remediate.py
+++ b/autoremediate/aws/lambda/AWS_EC2_ebs_recent_snapshot_remediate.py
@@ -51,7 +51,7 @@ def lambda_handler(event, context):
 
     # If the signature didn't report a failure, exit..
     #
-    if status != 'fail':
+    if (status != 'fail' and status != 'warn'):
         print('=> Nothing to do.')
         exit()
 
@@ -69,7 +69,7 @@ def lambda_handler(event, context):
     region = re.sub('_','-',regions['attributes']['code'])
 
     try:
-        volume = metadata['attributes']['data']['resource_id']
+        volume = alert['data']['attributes']['resource']
     except Exception as e:
         print('=> No EBS Volumes to evaluate.')
     else:

--- a/autoremediate/aws/lambda/AWS_EC2_instances_nonpri_regions_remediate.py
+++ b/autoremediate/aws/lambda/AWS_EC2_instances_nonpri_regions_remediate.py
@@ -49,7 +49,7 @@ def lambda_handler(event, context):
 
     # If the signature didn't report a failure, exit..
     #
-    if status != 'fail':
+    if (status != 'fail' and status != 'warn'):
         print('=> Nothing to do.')
         exit()
 
@@ -67,7 +67,7 @@ def lambda_handler(event, context):
     region = re.sub('_','-',regions['attributes']['code'])
 
     try:
-        instance_id = metadata['attributes']['data']['resource_id']
+        instance_id = alert['data']['attributes']['resource']
     except:
         print('=> No instances to evaluate.')
     else:

--- a/autoremediate/aws/lambda/AWS_EC2_public_ami_remediate.py
+++ b/autoremediate/aws/lambda/AWS_EC2_public_ami_remediate.py
@@ -52,7 +52,7 @@ def lambda_handler(event, context):
 
     # If the signature didn't report a failure, exit..
     #
-    if status != 'fail':
+    if (status != 'fail' and status != 'warn'):
         print('=> Nothing to do.')
         exit()
 
@@ -70,7 +70,7 @@ def lambda_handler(event, context):
     region = re.sub('_','-',regions['attributes']['code'])
 
     try:
-        img_id = metadata['attributes']['data']['resource_id']
+        img_id = alert['data']['attributes']['resource']
     except:
         print('=> No AMI to evaluate.')
     else:

--- a/autoremediate/aws/lambda/AWS_EC2_security_group_global_inbound_remediate.py
+++ b/autoremediate/aws/lambda/AWS_EC2_security_group_global_inbound_remediate.py
@@ -55,7 +55,7 @@ def lambda_handler(event, context):
 
     # If the signature didn't report a failure, exit..
     #
-    if status != 'fail':
+    if (status != 'fail' and status != 'warn'):
         print('=> Nothing to do.')
         exit()
 
@@ -73,7 +73,7 @@ def lambda_handler(event, context):
     region = re.sub('_','-',regions['attributes']['code'])
 
     try:
-        sg_id = metadata['attributes']['data']['resource_id']
+        sg_id = alert['data']['attributes']['resource']
     except:
         print('=> No security group to evaluate.')
     else:

--- a/autoremediate/aws/lambda/AWS_EC2_security_group_lock_down.py
+++ b/autoremediate/aws/lambda/AWS_EC2_security_group_lock_down.py
@@ -72,7 +72,7 @@ def lambda_handler(event, context):
 
     # If the signature didn't report a failure, exit..
     #
-    if status != 'fail':
+    if (status != 'fail' and status != 'warn'):
         print('=> Nothing to do.')
         exit()
 
@@ -90,7 +90,7 @@ def lambda_handler(event, context):
     region = re.sub('_','-',regions['attributes']['code'])
 
     try:
-        sg_id = metadata['attributes']['data']['resource_id']
+        sg_id = alert['data']['attributes']['resource']
     except:
         print('=> No security group to evaluate.')
     else:

--- a/autoremediate/aws/lambda/AWS_RDS_public_snapshot_remediate.py
+++ b/autoremediate/aws/lambda/AWS_RDS_public_snapshot_remediate.py
@@ -45,7 +45,7 @@ def lambda_handler(event, context):
 
     # If the signature didn't report a failure, exit..
     #
-    if status != 'fail':
+    if (status != 'fail' and status != 'warn'):
         print('=> Nothing to do.')
         exit()
 
@@ -63,7 +63,7 @@ def lambda_handler(event, context):
     region = re.sub('_','-',regions['attributes']['code'])
 
     try:
-        db_snap_id = metadata['attributes']['data']['resource_id']
+        db_snap_id = alert['data']['attributes']['resource']
     except Exception as e:
         print('=> No RDS snapshot to evaluate.')
     else:

--- a/autoremediate/aws/lambda/AWS_S3_public_acl_remediate.py
+++ b/autoremediate/aws/lambda/AWS_S3_public_acl_remediate.py
@@ -52,7 +52,7 @@ def lambda_handler(event, context):
 
     # If the signature didn't report a failure, exit..
     #
-    if status != 'fail':
+    if (status != 'fail' and status != 'warn'):
         print('=> Nothing to do.')
         exit()
 
@@ -70,7 +70,7 @@ def lambda_handler(event, context):
     region = re.sub('_','-',regions['attributes']['code'])
 
     try:
-        bucket = metadata['attributes']['data']['resource_id']
+        bucket = alert['data']['attributes']['resource']
     except:
         print('=> No S3 Bucket to evaluate.')
     else:


### PR DESCRIPTION
- Changed the condition to trigger auto-remediation to both fail and warn. (for some scripts, not all)
- Changed how resource is retrieved.  The previous method of metadata['attributes']['data']['resource_id'] doesn't seem to work anymore.